### PR TITLE
Move Installation Warning to Installation Section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,13 @@
 FANCY A STORY
 =============
 
+![](screenshots/overview.webp)
+
+[Read the **documentation**](https://elsatam.github.io/obsidian-fancy-a-story/) to see how to use all the features and settings of the theme!
+
+
+Installation
+------------
 > [!WARNING]
 > **Minimal Installer version**: 1.6.5
 > 
@@ -9,14 +16,6 @@ FANCY A STORY
 > **How to solve**: if the Installer version is too low, download the latest version of Obsidian from the official website and install it again.
 >
 > ![](screenshots/installer_version.png)
-
-![](screenshots/overview.webp)
-
-[Read the **documentation**](https://elsatam.github.io/obsidian-fancy-a-story/) to see how to use all the features and settings of the theme!
-
-
-Installation
-------------
 
 ### From Obsidian community themes
 


### PR DESCRIPTION
The warning about the installer version is currently at the top of the README in front of the preview images.

**Current position:**
<img width="864" alt="image" src="https://github.com/user-attachments/assets/9bcf8d17-446c-4108-8532-a22859e21a24">


It would make more sense to have the warning about the Obsidian Installer in the Installation section of the README that way users only see the warning if they plan on installing the theme.

**New position:**
<img width="861" alt="image" src="https://github.com/user-attachments/assets/a0c44467-df19-418b-ac8a-9a7b01e73593">
