### PR TITLE
Feat art deco callout no decoration + docs

### DIFF
--- a/docs/docs/skins/skins.md
+++ b/docs/docs/skins/skins.md
@@ -23,6 +23,14 @@ The fonts used in the screenshot are not directly included in the theme but can 
 
 You can also download and install them directly on your computer: [ParkLaneNF](https://www.1001fonts.com/parklane-font.html), [Semplicità](https://www.1001fonts.com/semplicita-font.html), [Limelight](https://fonts.google.com/specimen/Limelight), [Federo](https://fonts.google.com/specimen/Federo)
 
+## Callout
+
+Art Deco adds by default a decoration to every callout. This decoration makes by default the callout to be full width. If you want to remove the decoration, you can disable it using
+
+```md
+> [!callout|no-deco] Callout
+> Text
+```
 
 ## Pick your changes
 

--- a/scss/skins/_art-deco.scss
+++ b/scss/skins/_art-deco.scss
@@ -297,6 +297,7 @@ $fwi_sel: "";
         .callout:not(
             :where(
                     [data-callout-metadata~="blank"],
+					[data-callout-metadata~="no-deco"],
                     [data-callout="autopsy"],
                     [data-callout="caption"],
                     [data-callout="clue"],
@@ -326,11 +327,13 @@ $fwi_sel: "";
                 )
                 *
         ) {
-        clear: both;
+		
+		clear: both;
         overflow: visible;
         margin-bottom: calc(1em + 23px);
         border-bottom-width: 0;
         padding-bottom: 30px;
+
 
         &[data-callout-metadata~="accent"]::after {
             --art-deco-color: var(--color-accent);
@@ -340,7 +343,7 @@ $fwi_sel: "";
             --art-deco-color: rgb(var(--callout-color));
         }
 
-        &::after {
+        &:not(:where([data-callout-metadata~="no-deco"]))::after {
             @include art-deco-gradient();
             --h: 47.001941;
             --ew: 113.10071;
@@ -351,7 +354,7 @@ $fwi_sel: "";
             display: block;
             position: absolute;
             bottom: -23px;
-            left: -15px;
+			left: -15px;
             right: -15px;
             height: calc(var(--H) * 1px);
             background-image: var(--art-deco-gradient);


### PR DESCRIPTION
As described in #33 

Allow art-deco callout to not have overflow visible. To do so, remove deco