### PR TITLE
Fix --callout-color for Obsidian 1.13+

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
 	"name": "Fancy-a-Story",
 	"version": "2.6.0",
-	"minAppVersion": "1.11.4",
+	"minAppVersion": "1.13.0",
 	"author": "Kapirklaa",
 	"authorUrl": "https://github.com/ElsaTam"
 }

--- a/snippets/editor/callouts/callout-cite.css
+++ b/snippets/editor/callouts/callout-cite.css
@@ -19,7 +19,7 @@ body {
   padding-inline-start: calc(var(--cite-decoration-width) + 5px);
   background: none;
   border: none;
-  border-inline-start: var(--blockquote-border-thickness) solid rgb(var(--callout-color));
+  border-inline-start: var(--blockquote-border-thickness) solid var(--callout-color);
 }
 .callout[data-callout~=cite-fas]:not(.is-collapsible) .callout-title,
 .callout[data-callout~=quote-fas]:not(.is-collapsible) .callout-title {
@@ -89,7 +89,7 @@ body {
     padding-inline-start: calc(var(--cite-decoration-width) + 5px);
     background: none;
     border: none;
-    border-inline-start: var(--blockquote-border-thickness) solid rgb(var(--callout-color));
+    border-inline-start: var(--blockquote-border-thickness) solid var(--callout-color);
   }
   .callout[data-callout~=cite]:not(.is-collapsible) .callout-title,
   .callout[data-callout~=quote]:not(.is-collapsible) .callout-title {


### PR DESCRIPTION
Hello! I'm [saberzero1](https://github.com/saberzero1), a [community reviewer](https://obsidian.md/help/credits#Community+review) for Obsidian plugins and themes. We're sending this PR out to you proactively to help you prepare for a recent Obsidian update.

## Summary

Obsidian 1.13 changed how `--callout-color` works. It now provides a valid CSS color value (e.g. `rgb(255, 0, 128)`) instead of a bare RGB triplet (`255, 0, 128`).

This breaks two patterns:

**1. Bare RGB triplets in declarations:**
```css
/* Before (broken on 1.13+) */
--callout-color: 255, 0, 128;
/* After */
--callout-color: rgb(255, 0, 128);
```

**2. Wrapping `var(--callout-color)` in `rgb()`/`rgba()`:**
```css
/* Before (produces invalid rgb(rgb(...)) on 1.13+) */
background: rgba(var(--callout-color), 0.1);
/* After */
background: color-mix(in srgb, var(--callout-color) 10%, transparent);
```

## Changes

- Wrapped bare RGB triplets in `--callout-color` declarations with `rgb()`
- Replaced `rgb(var(--callout-color))` with `var(--callout-color)`
- Replaced `rgba(var(--callout-color), <alpha>)` with `color-mix(in srgb, var(--callout-color) <percent>, transparent)`
- Updated `minAppVersion` in `manifest.json` to `1.13.0` (if it was lower)

## Context

See the [Obsidian 1.13 changelog](https://obsidian.md/changelog/) for details on this breaking change.
