### PR TITLE
fix: cover note background mask across the reading view and scrollbar gutter

### DIFF
--- a/scss/cssclasses/_background-image.scss
+++ b/scss/cssclasses/_background-image.scss
@@ -41,21 +41,64 @@ body {
             brightness(var(--fas-note-background-image-brightness));
     }
 
-    /* Preview scrollbar */
-    body:not(.native-scrollbars).fas-note-background-image
-        .markdown-preview-view:not(.no-background, .no-bg)::-webkit-scrollbar-track,
-    body:not(.native-scrollbars) .markdown-preview-view:is(.background-img, .bg-img)::-webkit-scrollbar-track {
-        background-color: color-mix(
-            in srgb,
-            var(--workleaves-background),
-            transparent calc(100% * var(--fas-note-background-image-opacity))
-        );
+    /* Preview background compositor
+     *
+     * Obsidian 1.13 reserves the scrollbar gutter outside the preview's
+     * scrollport. Render the image and its effects on the fixed reading-view
+     * wrapper so a transparent scrollbar track still has a masked backdrop.
+     */
+    .fas-note-background-image
+        .markdown-reading-view:has(> .markdown-preview-view:not(.no-background, .no-bg)),
+    .markdown-reading-view:has(> .markdown-preview-view:is(.background-img, .bg-img)) {
+        position: relative;
+        isolation: isolate;
+        overflow: hidden;
+
+        &::before,
+        &::after {
+            content: "";
+            position: absolute;
+            z-index: -1;
+            pointer-events: none;
+        }
+
+        &::before {
+            inset: calc(-1 * var(--fas-note-background-image-blur));
+            background-color: var(--workleaves-background);
+            background-image: var(--fas-note-background-image-url);
+            background-blend-mode: var(--fas-note-background-image-blend-mode);
+            filter: blur(var(--fas-note-background-image-blur))
+                brightness(var(--fas-note-background-image-brightness));
+        }
+
+        &::after {
+            inset: 0;
+            background-color: color-mix(
+                in srgb,
+                var(--workleaves-background),
+                transparent calc(100% * var(--fas-note-background-image-opacity))
+            );
+        }
     }
 
-    /* Preview, needs resizing so it covers the whole image */
+    /* Preview scrollbar */
+    body:not(.native-scrollbars).fas-note-background-image
+        .markdown-preview-view:not(.no-background, .no-bg),
+    body:not(.native-scrollbars) .markdown-preview-view:is(.background-img, .bg-img) {
+        // Keep the thumb visible while letting the track blend into the note.
+        scrollbar-color: var(--scrollbar-thumb-bg) transparent !important;
+
+        &::-webkit-scrollbar,
+        &::-webkit-scrollbar-track {
+            background-color: transparent;
+        }
+    }
+
+    /* Preview layout */
     .fas-note-background-image .markdown-preview-view:not(.no-background, .no-bg),
     .markdown-preview-view:is(.background-img, .bg-img) {
         padding: 0;
+        background: transparent;
 
         > :first-child {
             padding-block: var(--file-margins-block);
@@ -64,13 +107,6 @@ body {
                 0.5 * (100% - var(--file-margins-inline) - var(--file-line-width)) + var(--scrollbar-width)
             );
             max-width: 100%;
-            background-color: color-mix(
-                in srgb,
-                var(--workleaves-background),
-                transparent calc(100% * var(--fas-note-background-image-opacity))
-            );
-            backdrop-filter: blur(var(--fas-note-background-image-blur))
-                brightness(var(--fas-note-background-image-brightness));
         }
     }
 }
@@ -79,7 +115,10 @@ body {
     .fas-note-background-image .markdown-source-view:not(.no-background, .no-bg),
     .fas-note-background-image .markdown-preview-view:not(.no-background, .no-bg),
     .markdown-source-view:is(.background-img, .bg-img),
-    .markdown-preview-view:is(.background-img, .bg-img) {
+    .markdown-preview-view:is(.background-img, .bg-img),
+    .fas-note-background-image
+        .markdown-reading-view:has(> .markdown-preview-view:not(.no-background, .no-bg))::before,
+    .markdown-reading-view:has(> .markdown-preview-view:is(.background-img, .bg-img))::before {
         background-size: cover;
         background-position: center;
     }
@@ -89,7 +128,10 @@ body {
     .fas-note-background-image .markdown-source-view:not(.no-background, .no-bg),
     .fas-note-background-image .markdown-preview-view:not(.no-background, .no-bg),
     .markdown-source-view:is(.background-img, .bg-img),
-    .markdown-preview-view:is(.background-img, .bg-img) {
+    .markdown-preview-view:is(.background-img, .bg-img),
+    .fas-note-background-image
+        .markdown-reading-view:has(> .markdown-preview-view:not(.no-background, .no-bg))::before,
+    .markdown-reading-view:has(> .markdown-preview-view:is(.background-img, .bg-img))::before {
         background-repeat: repeat;
     }
 }

--- a/snippets/cssclasses/background-image.css
+++ b/snippets/cssclasses/background-image.css
@@ -31,49 +31,74 @@ body {
 }
 
 @container (not (style(--fas-note-background-image-blur: 0) or style(--fas-note-background-image-blur: 0px))) or (not style(--fas-note-background-image-opacity: 1)) or (not style(--fas-note-background-image-brightness: 1)) {
-
   /* Source */
   .markdown-source-view:is(.background-img, .bg-img) .cm-editor {
     background-color: color-mix(in srgb, var(--workleaves-background), transparent calc(100% * var(--fas-note-background-image-opacity)));
     backdrop-filter: blur(var(--fas-note-background-image-blur)) brightness(var(--fas-note-background-image-brightness));
   }
-
-  /* Preview scrollbar */
-  body:not(.native-scrollbars) .markdown-preview-view:is(.background-img, .bg-img)::-webkit-scrollbar-track {
+  /* Preview background compositor
+   *
+   * Obsidian 1.13 reserves the scrollbar gutter outside the preview's
+   * scrollport. Render the image and its effects on the fixed reading-view
+   * wrapper so a transparent scrollbar track still has a masked backdrop.
+   */
+  .markdown-reading-view:has(> .markdown-preview-view:is(.background-img, .bg-img)) {
+    position: relative;
+    isolation: isolate;
+    overflow: hidden;
+  }
+  .markdown-reading-view:has(> .markdown-preview-view:is(.background-img, .bg-img))::before,
+  .markdown-reading-view:has(> .markdown-preview-view:is(.background-img, .bg-img))::after {
+    content: "";
+    position: absolute;
+    z-index: -1;
+    pointer-events: none;
+  }
+  .markdown-reading-view:has(> .markdown-preview-view:is(.background-img, .bg-img))::before {
+    inset: calc(-1 * var(--fas-note-background-image-blur));
+    background-color: var(--workleaves-background);
+    background-image: var(--fas-note-background-image-url);
+    background-blend-mode: var(--fas-note-background-image-blend-mode);
+    filter: blur(var(--fas-note-background-image-blur)) brightness(var(--fas-note-background-image-brightness));
+  }
+  .markdown-reading-view:has(> .markdown-preview-view:is(.background-img, .bg-img))::after {
+    inset: 0;
     background-color: color-mix(in srgb, var(--workleaves-background), transparent calc(100% * var(--fas-note-background-image-opacity)));
   }
-
-  /* Preview, needs resizing so it covers the whole image */
+  /* Preview scrollbar */
+  body:not(.native-scrollbars) .markdown-preview-view:is(.background-img, .bg-img) {
+    scrollbar-color: var(--scrollbar-thumb-bg) transparent !important;
+  }
+  body:not(.native-scrollbars) .markdown-preview-view:is(.background-img, .bg-img)::-webkit-scrollbar,
+  body:not(.native-scrollbars) .markdown-preview-view:is(.background-img, .bg-img)::-webkit-scrollbar-track {
+    background-color: transparent;
+  }
+  /* Preview layout */
   .markdown-preview-view:is(.background-img, .bg-img) {
     padding: 0;
+    background: transparent;
   }
-
-  .markdown-preview-view:is(.background-img, .bg-img)> :first-child {
+  .markdown-preview-view:is(.background-img, .bg-img) > :first-child {
     padding-block: var(--file-margins-block);
     padding-inline: max(var(--file-margins-inline), 0.5 * (100% - var(--file-margins-inline) - var(--file-line-width)) + var(--scrollbar-width));
     max-width: 100%;
-    background-color: color-mix(in srgb, var(--workleaves-background), transparent calc(100% * var(--fas-note-background-image-opacity)));
-    backdrop-filter: blur(var(--fas-note-background-image-blur)) brightness(var(--fas-note-background-image-brightness));
   }
 }
-
 @container style(--fas-note-background-image-repeat: no) {
-
   .markdown-source-view:is(.background-img, .bg-img),
-  .markdown-preview-view:is(.background-img, .bg-img) {
+  .markdown-preview-view:is(.background-img, .bg-img),
+  .markdown-reading-view:has(> .markdown-preview-view:is(.background-img, .bg-img))::before {
     background-size: cover;
     background-position: center;
   }
 }
-
 @container style(--fas-note-background-image-repeat: yes) {
-
   .markdown-source-view:is(.background-img, .bg-img),
-  .markdown-preview-view:is(.background-img, .bg-img) {
+  .markdown-preview-view:is(.background-img, .bg-img),
+  .markdown-reading-view:has(> .markdown-preview-view:is(.background-img, .bg-img))::before {
     background-repeat: repeat;
   }
 }
-
 :is(.background-img, .bg-img) .metadata-container {
   background-color: color-mix(in srgb, var(--workleaves-background), transparent 30%);
   backdrop-filter: blur(5px);


### PR DESCRIPTION
## Summary

- Render reading-mode note backgrounds on the fixed `.markdown-reading-view`
  wrapper so the mask covers the entire viewport on short notes.
- Keep the scrollbar track transparent while preserving the masked background
  underneath the scrollbar gutter on long notes.
- Preserve the existing global setting, per-note `background-img` / `bg-img`
  classes, opt-out classes, repeat mode, blur, brightness and opacity behavior.

## Cause

Obsidian 1.13 reserves the scrollbar gutter outside the preview scrollport.
The previous mask was painted on the preview content child, so it could not
cover the bottom of short notes or the scrollbar gutter of long notes.

#51 

## Testing

Tested with Obsidian 1.13.4 on macOS:

- Short, non-scrollable note
- Long, scrollable note
- Global “Enable note background image for all notes” setting
- `no-background` opt-out

<img width="1060" height="836" alt="image" src="https://github.com/user-attachments/assets/fcbb9801-6dd0-4f73-a411-816456c16be1" />
